### PR TITLE
fix invalid react native entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "name": "@nandorojo/iconic",
   "version": "0.0.1",
   "main": "lib/commonjs/index.js",
-  "react-native": "src/index.tsx",
+  "react-native": "src/index.ts",
   "module": "lib/module/index.js",
   "types": "lib/typescript/src/index.d.ts",
   "scripts": {


### PR DESCRIPTION
Fixes this build error in Expo Go

```
Android Bundling failed 28ms
While trying to resolve module `@nandorojo/iconic` from file `/Users/viljark/workspace/project/App.tsx`, the package `/Users/viljark/workspace/project/node_modules/@nandorojo/iconic/package.json` was successfully found. However, this package itself specifies a `main` module field that could not be resolved (`/Users/viljark/workspace/project/node_modules/@nandorojo/iconic/src/index.tsx`. Indeed, none of these files exist:

  * /Users/viljark/workspace/project/node_modules/@nandorojo/iconic/src/index.tsx(.native|.android.ts|.native.ts|.ts|.android.tsx|.native.tsx|.tsx|.android.js|.native.js|.js|.android.jsx|.native.jsx|.jsx|.android.json|.native.json|.json)
  * /Users/viljark/workspace/project/node_modules/@nandorojo/iconic/src/index.tsx/index(.native|.android.ts|.native.ts|.ts|.android.tsx|.native.tsx|.tsx|.android.js|.native.js|.js|.android.jsx|.native.jsx|.jsx|.android.json|.native.json|.json)
```